### PR TITLE
[C.1] Page-shell tokens single-source

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -9,6 +9,9 @@
 }
 
 :root {
+  --page-max-width: 1400px;
+  --page-inline-padding: clamp(20px, 5vw, 64px);
+
   /* Bioco Colors */
   --bioco-green: #2e7d32;
   --bioco-green-light: #4caf50;
@@ -75,7 +78,7 @@ body {
 
 /* CMS Section Renderer */
 .cms-sections {
-  max-width: 1400px;
+  max-width: var(--page-max-width);
   margin: 0 auto;
   padding: clamp(32px, 6vw, 96px) clamp(16px, 6vw, 96px);
 }
@@ -313,7 +316,7 @@ p {
   grid-auto-rows: min-content;
   align-content: start;
   width: 100%;
-  max-width: 1400px; /* Match navbar max-width for alignment */
+  max-width: var(--page-max-width); /* Match navbar max-width for alignment */
   box-sizing: border-box; /* Ensure padding is included in width calculation */
 }
 
@@ -1293,7 +1296,7 @@ a:hover {
 }
 
 .utility-nav-container {
-  max-width: 1400px; /* Match content max-width for alignment */
+  max-width: var(--page-max-width); /* Match content max-width for alignment */
   width: 100%;
   margin: 0 auto; /* Center the container */
   padding: 0 clamp(16px, 6vw, 96px); /* Match content horizontal padding exactly - ESSENTIAL for alignment */
@@ -1387,7 +1390,7 @@ a:hover {
 
 .primary-nav-container,
 .secondary-nav-container {
-  max-width: 1400px; /* Match content max-width */
+  max-width: var(--page-max-width); /* Match content max-width */
   width: 100%;
   margin: 0 auto; /* Center the container */
   padding: 0 clamp(16px, 6vw, 96px); /* Match content horizontal padding exactly - ESSENTIAL for alignment */
@@ -2540,7 +2543,7 @@ header .header-nav-container .beet-leaves {
 /* Ensure bento-grid uses full width */
 .bento-grid {
   width: 100%;
-  max-width: 1400px; /* Match navbar max-width for alignment */
+  max-width: var(--page-max-width); /* Match navbar max-width for alignment */
   margin-left: auto; /* Center the grid */
   margin-right: auto; /* Center the grid */
 }
@@ -2910,7 +2913,7 @@ footer {
 
 /* Footer content wrapper - aligns with logo position */
 #footer-content {
-  max-width: 1400px; /* Match nav container max-width */
+  max-width: var(--page-max-width); /* Match nav container max-width */
   width: 100%;
   margin: 0 auto;
   padding: 0 clamp(16px, 6vw, 96px); /* Match logo/nav container left padding */
@@ -5507,7 +5510,7 @@ footer a:hover {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: var(--spacing-xl) var(--spacing-lg);
-  max-width: 1400px;
+  max-width: var(--page-max-width);
   margin: 0 auto;
 }
 
@@ -5793,7 +5796,7 @@ footer a:hover {
 .hero-bleed {
   position: relative;
   width: 100%;
-  max-width: 1400px;
+  max-width: var(--page-max-width);
   margin: 0 auto;
   margin-top: clamp(16px, 3vw, 32px); /* Decreased space by half between secondary nav and hero image */
   height: clamp(50vh, 65vh, 70vh);
@@ -5845,7 +5848,7 @@ footer a:hover {
 .hero-utility-nav {
   position: relative;
   width: 100%;
-  max-width: 1400px;
+  max-width: var(--page-max-width);
   margin: 0 auto;
   margin-top: clamp(16px, 3vw, 32px);
   padding: 0 clamp(16px, 6vw, 96px);
@@ -5899,7 +5902,7 @@ footer a:hover {
   position: relative;
   z-index: 2;
   background: var(--bg-secondary);
-  max-width: 1400px;
+  max-width: var(--page-max-width);
   margin: 0 auto;
   padding: clamp(0px, calc(8vw - 50px), 46px) clamp(16px, 6vw, 96px) clamp(32px, 6vw, 64px); /* Reduced top padding by 50px */
 }
@@ -5914,7 +5917,7 @@ footer a:hover {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: clamp(16px, 4vw, 32px);
-  max-width: 1400px;
+  max-width: var(--page-max-width);
   margin: 0 auto;
 }
 
@@ -5956,7 +5959,7 @@ footer a:hover {
   grid-template-columns: 1fr;
   gap: clamp(24px, 6vw, 48px);
   width: 100%;
-  max-width: 1400px;
+  max-width: var(--page-max-width);
   margin: clamp(48px, 8vw, 96px) auto;
   padding: 0 clamp(16px, 6vw, 96px);
 }

--- a/frontend/tests/page-shell-tokens.test.ts
+++ b/frontend/tests/page-shell-tokens.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+// C.1 — page-shell tokens must be the single source of truth for the shell width.
+const read = (p: string) => readFileSync(path.resolve(__dirname, '..', p), 'utf8')
+const globals = read('app/globals.css')
+const tokens = read('app/tokens.css')
+const css = globals + '\n' + tokens
+
+const countDefs = (name: string) =>
+  (css.match(new RegExp(`--${name}\\s*:`, 'g')) || []).length
+
+describe('page-shell tokens (C.1)', () => {
+  it('defines --page-max-width exactly once', () => {
+    expect(countDefs('page-max-width')).toBe(1)
+  })
+
+  it('defines --page-inline-padding exactly once', () => {
+    expect(countDefs('page-inline-padding')).toBe(1)
+  })
+
+  it('uses the shell width literal 1400px only in the token definition', () => {
+    // Allowed: the single `--page-max-width: 1400px;` definition.
+    // Disallowed: every other `max-width: 1400px` magic number.
+    const stray = (css.match(/1400px/g) || []).length
+    const inTokenDef = (css.match(/--page-max-width\s*:\s*1400px/g) || []).length
+    expect(stray - inTokenDef).toBe(0)
+  })
+})


### PR DESCRIPTION
Closes #51 · Epic #46

Single source of truth for the shell width. Adds `--page-max-width` + `--page-inline-padding`, replaces 12 duplicated `max-width:1400px` literals with `var(--page-max-width)`.

Test-first: `tests/page-shell-tokens.test.ts` (tokens defined once; no stray `1400px`). Full suite 113/113 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)