### PR TITLE
[C.2] Hero adopts page shell (logo-aligned)

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -39,6 +39,8 @@
   --spacing-lg: 32px;
   --spacing-xl: 48px;
   --spacing-2xl: 64px;
+  --page-max-width: 1400px;
+  --page-inline-padding: clamp(16px, 6vw, 96px);
   --mobile-nav-height: 60px;
   --cms-h1-color: #1a1a1a;
   --cms-h1-font-size-mobile: calc(1.375rem + 1.5vw);
@@ -1387,10 +1389,10 @@ a:hover {
 
 .primary-nav-container,
 .secondary-nav-container {
-  max-width: 1400px; /* Match content max-width */
+  max-width: var(--page-max-width); /* Match content max-width */
   width: 100%;
   margin: 0 auto; /* Center the container */
-  padding: 0 clamp(16px, 6vw, 96px); /* Match content horizontal padding exactly - ESSENTIAL for alignment */
+  padding: 0 var(--page-inline-padding); /* Match content horizontal padding exactly - ESSENTIAL for alignment */
   display: flex;
   align-items: center;
   gap: var(--spacing-md);
@@ -2378,9 +2380,9 @@ header .header-nav-container .beet-leaves {
   grid-template-columns: 1fr 2fr;
   gap: var(--spacing-md);
   width: 100%;
-  max-width: 100%;
+  max-width: var(--page-max-width);
   margin: 0 auto;
-  padding: 0 clamp(var(--spacing-sm), 5vw, 150px);
+  padding: 0 var(--page-inline-padding);
 }
 
 .hero-image-card {

--- a/frontend/tests/alignment.spec.ts
+++ b/frontend/tests/alignment.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test'
+
+// C.2 — logo, lead heading, and intro paragraph must share one left edge.
+// Needs a live server WITH the ProcessWire backend (hero is CMS-fed), so this
+// runs in CI / manual verify against a deployed build, not in the unit loop.
+// Run: BASE_URL=https://www.bioco.ch npx playwright test alignment.spec.ts
+const PAGES = ['/wir', '/abos']
+const TOL = 2 // px
+
+for (const route of PAGES) {
+  test(`left edges align on ${route}`, async ({ page }) => {
+    await page.goto(route)
+    const logo = await page.locator('.primary-nav-logo, .secondary-nav-logo').first().boundingBox()
+    const heading = await page.locator('h1, .hero-title, .cms-section-title h2').first().boundingBox()
+    expect(logo, 'logo box').toBeTruthy()
+    expect(heading, 'heading box').toBeTruthy()
+    expect(Math.abs((logo!.x) - (heading!.x))).toBeLessThanOrEqual(TOL)
+  })
+}

--- a/frontend/tests/hero-shell-alignment.test.ts
+++ b/frontend/tests/hero-shell-alignment.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+// C.2 — hero and nav must share the SAME shell tokens so the hero text left
+// edge lines up with the logo. Deterministic CSS-contract test (the pixel-level
+// check lives in tests/alignment.spec.ts, which needs a live server + CMS).
+const css = readFileSync(path.resolve(__dirname, '..', 'app/globals.css'), 'utf8')
+
+// grab the declaration block for a selector group (first match)
+function block(selector: string): string {
+  const i = css.indexOf(selector)
+  expect(i, `selector ${selector} not found`).toBeGreaterThan(-1)
+  const open = css.indexOf('{', i)
+  const close = css.indexOf('}', open)
+  return css.slice(open + 1, close)
+}
+
+const nav = block('.primary-nav-container')
+const hero = block('.hero-container')
+
+describe('hero shares the page shell (C.2)', () => {
+  it('nav container consumes both shell tokens', () => {
+    expect(nav).toMatch(/max-width:\s*var\(--page-max-width\)/)
+    expect(nav).toMatch(/var\(--page-inline-padding\)/)
+  })
+
+  it('hero container consumes both shell tokens', () => {
+    expect(hero).toMatch(/max-width:\s*var\(--page-max-width\)/)
+    expect(hero).toMatch(/var\(--page-inline-padding\)/)
+  })
+
+  it('inline-padding token equals the canonical nav padding', () => {
+    expect(css).toMatch(/--page-inline-padding:\s*clamp\(16px,\s*6vw,\s*96px\)/)
+  })
+})


### PR DESCRIPTION
Closes #53 · Epic #46

Fixes the hero-text indent (Image #1). Hero used `max-width:100%` + a different padding than the nav; now both `.primary-nav-container` and `.hero-container` consume `var(--page-max-width)` + `var(--page-inline-padding)` (= the canonical nav padding `clamp(16px,6vw,96px)`), so the hero heading lines up with the logo.

- `tests/hero-shell-alignment.test.ts` — deterministic CSS-contract (RED→GREEN), suite 113/113.
- `tests/alignment.spec.ts` — Playwright pixel check for CI/human (needs live server + CMS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)