### PR TITLE
[C.3] PageHeader heading contract

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -6417,3 +6417,25 @@ footer a:hover {
     padding-top: calc(clamp(24px, 4vw, 48px) + var(--mobile-nav-height)) !important;
   }
 }
+
+/* C.3 — canonical page heading contract (shell-aligned, tokenized spacing) */
+.page-header {
+  width: 100%;
+  max-width: var(--page-max-width);
+  margin: 0 auto;
+  padding: var(--spacing-xl) var(--page-inline-padding) var(--spacing-md);
+  box-sizing: border-box;
+}
+.page-header-eyebrow {
+  margin: 0 0 var(--spacing-xs);
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+.page-header-title {
+  margin: 0 0 var(--spacing-md);
+}
+.page-header-intro {
+  margin: 0;
+  max-width: 60ch;
+  color: var(--text-secondary);
+}

--- a/frontend/components/PageHeader.tsx
+++ b/frontend/components/PageHeader.tsx
@@ -1,0 +1,23 @@
+import { ReactNode } from 'react'
+
+interface PageHeaderProps {
+  eyebrow?: string
+  title: ReactNode
+  intro?: ReactNode
+}
+
+/**
+ * Canonical page heading (C.3). Exactly one <h1> per page, with optional
+ * eyebrow above and intro below. Shell-aligned + tokenized spacing via
+ * the .page-header CSS rules, so the lead heading sits identically on
+ * hardcoded and CMS-driven pages.
+ */
+export function PageHeader({ eyebrow, title, intro }: PageHeaderProps) {
+  return (
+    <header className="page-header">
+      {eyebrow ? <p className="page-header-eyebrow">{eyebrow}</p> : null}
+      <h1 className="page-header-title">{title}</h1>
+      {intro ? <p className="page-header-intro">{intro}</p> : null}
+    </header>
+  )
+}

--- a/frontend/tests/heading-contract.spec.ts
+++ b/frontend/tests/heading-contract.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test'
+
+// C.3 — every page has exactly one <h1>; in-page section titles are <h2>.
+// Needs a live server (CMS-fed); runs in CI / manual verify.
+// Run: BASE_URL=https://www.bioco.ch npx playwright test heading-contract.spec.ts
+for (const route of ['/wir', '/abos']) {
+  test(`exactly one h1 on ${route}`, async ({ page }) => {
+    await page.goto(route)
+    await expect(page.locator('h1')).toHaveCount(1)
+  })
+}

--- a/frontend/tests/page-header.test.tsx
+++ b/frontend/tests/page-header.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { PageHeader } from '@/components/PageHeader'
+
+// C.3 — canonical page heading contract: eyebrow -> single h1 -> intro.
+describe('PageHeader (C.3)', () => {
+  it('renders exactly one h1 carrying the title', () => {
+    render(<PageHeader title="Seit 2014" />)
+    const h1s = screen.getAllByRole('heading', { level: 1 })
+    expect(h1s).toHaveLength(1)
+    expect(h1s[0]).toHaveTextContent('Seit 2014')
+  })
+
+  it('renders eyebrow and intro when provided, in order eyebrow -> h1 -> intro', () => {
+    const { container } = render(
+      <PageHeader eyebrow="Über uns" title="Titel" intro="Kurzer Vorspann." />
+    )
+    expect(screen.getByText('Über uns')).toBeInTheDocument()
+    expect(screen.getByText('Kurzer Vorspann.')).toBeInTheDocument()
+    const order = Array.from(container.querySelectorAll('.page-header-eyebrow, h1, .page-header-intro'))
+    expect(order.map((el) => el.className.includes('eyebrow') ? 'eyebrow' : el.tagName === 'H1' ? 'h1' : 'intro'))
+      .toEqual(['eyebrow', 'h1', 'intro'])
+  })
+
+  it('omits eyebrow/intro when not provided', () => {
+    render(<PageHeader title="Nur Titel" />)
+    expect(screen.queryByText('Über uns')).not.toBeInTheDocument()
+  })
+
+  it('.page-header is tokenized + shell-aligned in CSS', () => {
+    const css = readFileSync(path.resolve(__dirname, '..', 'app/globals.css'), 'utf8')
+    const i = css.indexOf('.page-header')
+    expect(i, '.page-header rule missing').toBeGreaterThan(-1)
+    const block = css.slice(i, css.indexOf('}', i))
+    // spacing comes from tokens, not raw magic numbers
+    expect(block).toMatch(/var\(--(spacing|page-)/)
+  })
+})


### PR DESCRIPTION
Closes #55 · Epic #46

Reusable `PageHeader` (eyebrow→h1→intro), shell-aligned + tokenized `.page-header` spacing, so the lead heading is one canonical `<h1>` on both hardcoded and CMS pages.

- `tests/page-header.test.tsx` — structure + tokenized-CSS contract (RED→GREEN).
- `tests/heading-contract.spec.ts` — Playwright one-h1/page (CI/human, live server).

Adoption (swapping page lead headings to PageHeader) is follow-up per page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)