### PR TITLE
[E.1] Visible focus-visible a11y guardrails

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -8,6 +8,19 @@
   padding: 0;
 }
 
+/* Accessible keyboard focus */
+a:focus-visible,
+button:focus-visible,
+.btn:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible,
+.primary-nav a:focus-visible {
+  outline: 3px solid var(--bioco-green);
+  outline-offset: 3px;
+  box-shadow: 0 0 0 5px rgba(255, 255, 255, 0.95);
+}
+
 :root {
   /* Bioco Colors */
   --bioco-green: #2e7d32;

--- a/frontend/tests/focus-visible.test.ts
+++ b/frontend/tests/focus-visible.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+// E.1 — keyboard focus must be visible. Deterministic CSS-contract; the
+// in-browser axe/focus check lives in tests/visual-polish-a11y.spec.ts.
+const css = readFileSync(path.resolve(__dirname, '..', 'app/globals.css'), 'utf8')
+
+// collect the body of every :focus-visible rule
+function focusVisibleRules(): string {
+  const rules: string[] = []
+  const re = /:focus-visible[^{]*\{([^}]*)\}/g
+  let m: RegExpExecArray | null
+  while ((m = re.exec(css))) rules.push(m[0])
+  return rules.join('\n')
+}
+
+describe('focus-visible a11y (E.1)', () => {
+  const rules = focusVisibleRules()
+
+  it('defines at least one :focus-visible rule', () => {
+    expect(rules.length).toBeGreaterThan(0)
+  })
+
+  it('provides a visible indicator (outline or box-shadow), not outline:none', () => {
+    expect(rules).toMatch(/outline:\s*(?!none)[^;]+|box-shadow:\s*[^;]+/)
+    expect(rules).not.toMatch(/outline:\s*none/)
+  })
+
+  it('covers core interactive elements (links, buttons, .btn)', () => {
+    // the union of all :focus-visible selectors must mention these
+    const selectors = (css.match(/[^{};]*:focus-visible/g) || []).join(' ')
+    expect(selectors).toMatch(/\ba\b|\.btn|button/)
+  })
+})

--- a/frontend/tests/visual-polish-a11y.spec.ts
+++ b/frontend/tests/visual-polish-a11y.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test'
+
+// E.1 — every interactive element shows a visible focus indicator.
+// Needs a live server; runs in CI / manual verify (no axe dep required).
+// Run: BASE_URL=https://www.bioco.ch npx playwright test visual-polish-a11y.spec.ts
+test('primary CTA has a visible focus indicator', async ({ page }) => {
+  await page.goto('/')
+  const cta = page.locator('a.btn, button.btn').first()
+  await cta.focus()
+  const styles = await cta.evaluate((el) => {
+    const s = getComputedStyle(el)
+    return { outline: s.outlineStyle, outlineWidth: s.outlineWidth, shadow: s.boxShadow }
+  })
+  const visible = (styles.outline !== 'none' && styles.outlineWidth !== '0px') || styles.shadow !== 'none'
+  expect(visible, JSON.stringify(styles)).toBeTruthy()
+})


### PR DESCRIPTION
Closes #57 · Epic #47

Adds visible keyboard-focus indicators (links, buttons, .btn, form controls, nav) — previously none existed and inputs used `outline:none`. 3px `var(--bioco-green)` outline + offset, WCAG AA.

- `tests/focus-visible.test.ts` — CSS-contract (RED→GREEN).
- `tests/visual-polish-a11y.spec.ts` — Playwright focus check (CI/human, live server, no axe dep).

Note: touches `app/globals.css` like the Track C PRs; merge order/rebase needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)