### PR TITLE
[B.1] Route editability classifier + completeness

### DIFF
--- a/frontend/lib/editabilityAudit.ts
+++ b/frontend/lib/editabilityAudit.ts
@@ -1,0 +1,41 @@
+// CMS-editability audit (B.1): route ownership and expected change path.
+export type RouteStatus = 'cms' | 'hardcoded'
+
+export interface AuditEntry {
+  status: RouteStatus
+  changePath: 'inline' | 'pw' | 'ticket'
+  pwPageId?: number
+  notes?: string
+}
+
+export const AUDIT: Record<string, AuditEntry> = {
+  '/': { status: 'hardcoded', changePath: 'pw' },
+  '/(cms)/[...slug]': { status: 'cms', changePath: 'inline' },
+  '/abos': { status: 'cms', changePath: 'inline' },
+  '/aktuelles': { status: 'hardcoded', changePath: 'pw' },
+  '/anmeldung': { status: 'hardcoded', changePath: 'ticket' },
+  '/anmeldung/danke': { status: 'hardcoded', changePath: 'ticket' },
+  '/bioco-werden': { status: 'hardcoded', changePath: 'ticket' },
+  '/datenschutz': { status: 'hardcoded', changePath: 'ticket' },
+  '/doi-confirm': { status: 'hardcoded', changePath: 'ticket' },
+  '/gemuese': { status: 'hardcoded', changePath: 'pw' },
+  '/impressum': { status: 'hardcoded', changePath: 'ticket' },
+  '/kontakt': { status: 'hardcoded', changePath: 'pw' },
+  '/kundenportal': { status: 'hardcoded', changePath: 'ticket' },
+  '/mitmachen': { status: 'hardcoded', changePath: 'pw' },
+  '/newsletter': { status: 'hardcoded', changePath: 'ticket' },
+  '/solawi': { status: 'hardcoded', changePath: 'pw' },
+  '/standorte-depots': { status: 'hardcoded', changePath: 'ticket' },
+  '/statuten': { status: 'hardcoded', changePath: 'ticket' },
+  '/tag-der-offenen-tuer': { status: 'hardcoded', changePath: 'ticket' },
+  '/warteliste': { status: 'hardcoded', changePath: 'ticket' },
+  '/wir': { status: 'hardcoded', changePath: 'pw' },
+}
+
+export function classifyRoute(route: string): RouteStatus {
+  const entry = AUDIT[route]
+  if (!entry) {
+    throw new Error(`Route is not in editability audit: ${route}`)
+  }
+  return entry.status
+}

--- a/frontend/tests/editability-audit.test.ts
+++ b/frontend/tests/editability-audit.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { readdirSync } from 'node:fs'
+import path from 'node:path'
+import { AUDIT, classifyRoute } from '@/lib/editabilityAudit'
+
+// B.1 — every route is classified cms | hardcoded, and the audit map stays
+// complete: adding a new page.tsx without classifying it fails this test.
+function routeFiles(dir: string, base = 'app'): string[] {
+  const out: string[] = []
+  for (const e of readdirSync(path.resolve(__dirname, '..', dir), { withFileTypes: true })) {
+    if (e.isDirectory()) out.push(...routeFiles(path.join(dir, e.name), base))
+    else if (e.name === 'page.tsx') {
+      const route = '/' + path.relative(base, dir).split(path.sep).join('/')
+      out.push(route === '/' ? '/' : route.replace(/\/$/, ''))
+    }
+  }
+  return out
+}
+const routes = routeFiles('app')
+
+describe('editability audit (B.1)', () => {
+  it('classifies known routes', () => {
+    expect(classifyRoute('/abos')).toBe('cms')
+    expect(classifyRoute('/(cms)/[...slug]')).toBe('cms')
+    expect(classifyRoute('/wir')).toBe('hardcoded')
+    expect(classifyRoute('/impressum')).toBe('hardcoded')
+  })
+
+  it('throws on an unknown route', () => {
+    expect(() => classifyRoute('/does-not-exist')).toThrow()
+  })
+
+  it('audit map covers every page.tsx route (completeness)', () => {
+    const missing = routes.filter((r) => !(r in AUDIT))
+    expect(missing, `unclassified routes: ${missing.join(', ')}`).toEqual([])
+  })
+
+  it('every entry has a change path (inline | pw | ticket)', () => {
+    for (const [route, entry] of Object.entries(AUDIT)) {
+      expect(['cms', 'hardcoded'], route).toContain(entry.status)
+      expect(entry.changePath, route).toMatch(/inline|pw|ticket/)
+    }
+  })
+})


### PR DESCRIPTION
Closes #59 · Epic #48

`lib/editabilityAudit.ts` classifies all 21 routes as `cms` | `hardcoded` with a change path (`inline`/`pw`/`ticket`). Confirms only `/abos` + `(cms)/[...slug]` are CMS-driven; the rest are hardcoded (matches CLAUDE.md).

`tests/editability-audit.test.ts` — classify + **completeness guard** (adding an unclassified `page.tsx` fails CI). RED→GREEN, suite 114/114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)