### PR TITLE
[B.2] PW deep-link builder

### DIFF
--- a/frontend/lib/pwDeeplink.ts
+++ b/frontend/lib/pwDeeplink.ts
@@ -1,0 +1,24 @@
+import type { AuditEntry } from './editabilityAudit'
+
+export type Affordance = 'inline' | 'pw-link' | 'ticket'
+
+export function pwEditUrl(pageId: number): string {
+  if (!Number.isFinite(pageId) || pageId <= 0) {
+    throw new Error('pageId must be a positive finite number')
+  }
+
+  const base = (process.env.NEXT_PUBLIC_PROCESSWIRE_BASE_URL || 'https://cms.bioco.ch').replace(/\/+$/, '')
+  return `${base}/processwire/page/edit/?id=${pageId}`
+}
+
+export function regionAffordance(entry: AuditEntry): Affordance {
+  switch (entry.changePath) {
+    case 'inline':
+      return 'inline'
+    case 'pw':
+      return 'pw-link'
+    case 'ticket':
+    default:
+      return 'ticket'
+  }
+}

--- a/frontend/tests/pw-deeplink.test.ts
+++ b/frontend/tests/pw-deeplink.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { pwEditUrl, regionAffordance } from '@/lib/pwDeeplink'
+import type { AuditEntry } from '@/lib/editabilityAudit'
+
+// B.2 — deep-link into ProcessWire + map an audit entry to its change affordance.
+describe('pwEditUrl (B.2)', () => {
+  it('builds the PW admin edit URL for a page id', () => {
+    expect(pwEditUrl(1740)).toMatch(/\/processwire\/page\/edit\/\?id=1740$/)
+  })
+  it('throws on a missing/invalid id', () => {
+    // @ts-expect-error invalid input
+    expect(() => pwEditUrl(undefined)).toThrow()
+    expect(() => pwEditUrl(0)).toThrow()
+  })
+})
+
+describe('regionAffordance (B.2)', () => {
+  const mk = (changePath: AuditEntry['changePath']): AuditEntry =>
+    ({ status: 'hardcoded', changePath })
+
+  it('maps change paths to affordances', () => {
+    expect(regionAffordance({ status: 'cms', changePath: 'inline' })).toBe('inline')
+    expect(regionAffordance(mk('pw'))).toBe('pw-link')
+    expect(regionAffordance(mk('ticket'))).toBe('ticket')
+  })
+
+  it('never returns "none" (every region has a change path)', () => {
+    for (const cp of ['inline', 'pw', 'ticket'] as const) {
+      expect(regionAffordance(mk(cp))).not.toBe('none')
+    }
+  })
+})


### PR DESCRIPTION
Closes #61 · Epic #48

`pwEditUrl(id)` builds the PW admin edit URL (validates id); `regionAffordance(entry)` maps an audit entry to `inline`|`pw-link`|`ticket` and **never** returns none — guarantees every region has a change path.

`tests/pw-deeplink.test.ts` RED→GREEN, suite 114/114.

⚠️ **Merge after #60** (B.1): type-only import of `AuditEntry` from `editabilityAudit.ts`. Runtime tests pass standalone; production build needs #60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)